### PR TITLE
Switcheroo for regex keyword case sensitivity

### DIFF
--- a/src/WazeBotDiscord/Keywords/KeywordService.cs
+++ b/src/WazeBotDiscord/Keywords/KeywordService.cs
@@ -501,19 +501,19 @@ namespace WazeBotDiscord.Keywords
         /// <returns>Boolean of if it's a regex format or not</returns>
         bool IsKeywordRegex(string keyword)
         {
-            return keyword.StartsWith("/") && (keyword.EndsWith("/") || keyword.EndsWith("/s"));
+            return keyword.StartsWith("/") && (keyword.EndsWith("/") || keyword.EndsWith("/i"));
         }
 
         Regex CreateRegex(string keyword)
         {
             var options = RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Multiline;
-            if (keyword.EndsWith("/s"))
+            if (keyword.EndsWith("/i"))
             {
+                options |= RegexOptions.IgnoreCase;
                 keyword = keyword.Substring(1, keyword.Length - 3);
             }
             else
             {
-                options |= RegexOptions.IgnoreCase;
                 keyword = keyword.Trim('/');
             }
 


### PR DESCRIPTION
SQL statements: 

Append the insentive flag onto the end of the existing RegEx
`UPDATE keyword SET keyword = CONCAT(keyword,'i') WHERE LEFT(keyword, 1) = '/' AND RIGHT(keyword, 1)='/';`

Remove our homemade sensitive flag at the end of the existing RegEx
`UPDATE keyword SET keyword = LEFT(keyword, LENGTH(keyword) - 1) WHERE LEFT(keyword, 1) = '/' AND RIGHT(keyword, 2) = '/s';`

Fixes #15 